### PR TITLE
Refactor Partner class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
    - spec/lib/etda_utilities_etda_file_paths_spec.rb
+   - spec/lib/etda_utilities_partner_spec.rb
 
 Metrics/MethodLength:
   Enabled: false

--- a/lib/etda_utilities/partner.rb
+++ b/lib/etda_utilities/partner.rb
@@ -18,6 +18,34 @@ module EtdaUtilities
 
     attr_reader :id
 
+    def email_list
+      attributes['email']['list']
+    end
+
+    def email_address
+      attributes['email']['address']
+    end
+
+    def name
+      attributes['name']
+    end
+
+    def slug
+      attributes['slug']
+    end
+
+    def program_label
+      attributes['program']['label']
+    end
+
+    def committee_label
+      attributes['committee']['label']
+    end
+
+    def committee_list_label
+      attributes['committee']['list']['label']
+    end
+
     def graduate?
       id == 'graduate'
     end
@@ -33,5 +61,12 @@ module EtdaUtilities
     def sset?
       id == 'sset'
     end
+
+    private
+
+      def attributes
+        file_path = File.join(File.dirname(__FILE__), 'partner.yml')
+        YAML.load_file(file_path.to_s)[id]
+      end
   end
 end

--- a/lib/etda_utilities/partner.yml
+++ b/lib/etda_utilities/partner.yml
@@ -1,0 +1,45 @@
+graduate:
+  slug: eTD
+  name: Graduate School
+  email:
+    address: gradthesis@psu.edu
+    list: 'ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com'
+  program:
+    label: Graduate Program
+  committee:
+    label: Committee Member
+    list:
+      label: Committee Members
+
+honors:
+  slug: eHT
+  name: Schreyer Honors College
+  email:
+    address: SHCAcademics@psu.edu
+    list: 'ul-etda-honors-admin@pennstateoffice365.onmicrosoft.com'
+  program:
+    label: Area of Honors
+  committee:
+    label: Thesis Supervisor
+    list:
+      label: Thesis Supervisors
+
+milsch:
+  slug: MSPT
+  name: Millennium Scholars Program
+  email:
+    address: millennium@psu.edu
+    list: 'ul-etda-milsch-admin@pennstateoffice365.onmicrosoft.com'
+  program:
+    label: Millennium Scholars Program Name
+  committee:
+    label: Thesis Supervisor
+    list:
+      label: Thesis Supervisor
+
+sset:
+  slug: SSETT
+  name: School of Science, Engineering, and Technology
+  email:
+    address: sset@psu.edu
+    list: 'ul-etda-sset-admin@pennstateoffice365.onmicrosoft.com'

--- a/spec/lib/etda_utilities_partner_spec.rb
+++ b/spec/lib/etda_utilities_partner_spec.rb
@@ -3,54 +3,133 @@
 RSpec.describe EtdaUtilities::Partner, type: :model do
   describe 'current_partner.id' do
     context "when ENV['PARTNER'] is graduate" do
+      let(:subject) { described_class.current }
       before do
         partner_set_env('graduate')
       end
 
       it 'sets current.id to graduate' do
-        expect(described_class.current.id).to eql('graduate')
+        expect(subject.id).to eql('graduate')
       end
       it 'responds to graduate?' do
-        expect(described_class.current).to be_graduate
+        expect(subject).to be_graduate
+      end
+      it 'returns partner name' do
+        expect(subject.name).to eq("Graduate School")
+      end
+      it 'returns partner email' do
+        expect(subject.email_address).to eq("gradthesis@psu.edu")
+      end
+      it 'returns partner email list' do
+        expect(subject.email_list).to eq('ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com')
+      end
+      it 'returns partner slug' do
+        expect(subject.slug).to eq("eTD")
+      end
+      it 'returns partner label' do
+        expect(subject.program_label).to eq("Graduate Program")
+      end
+      it 'returns partner committee label' do
+        expect(subject.committee_label).to eq("Committee Member")
+      end
+      it 'returns partner committee list label' do
+        expect(subject.committee_list_label).to eq("Committee Members")
       end
     end
 
     context "when ENV['PARTNER'] is honors" do
+      let(:subject) { described_class.current }
       before do
         partner_set_env('honors')
       end
 
       it 'sets current.id to honors' do
-        expect(described_class.current.id).to eql('honors')
+        expect(subject.id).to eql('honors')
       end
       it 'responds to honors?' do
-        expect(described_class.current).to be_honors
+        expect(subject).to be_honors
+      end
+      it 'returns partner name' do
+        expect(subject.name).to eq("Schreyer Honors College")
+      end
+      it 'returns partner email' do
+        expect(subject.email_address).to eq("SHCAcademics@psu.edu")
+      end
+      it 'returns partner email list' do
+        expect(subject.email_list).to eq('ul-etda-honors-admin@pennstateoffice365.onmicrosoft.com')
+      end
+      it 'returns partner slug' do
+        expect(subject.slug).to eq("eHT")
+      end
+      it 'returns partner label' do
+        expect(subject.program_label).to eq("Area of Honors")
+      end
+      it 'returns partner committee label' do
+        expect(subject.committee_label).to eq("Thesis Supervisor")
+      end
+      it 'returns partner committee list label' do
+        expect(subject.committee_list_label).to eq("Thesis Supervisors")
       end
     end
 
     context "when ENV['PARTNER'] is milsch" do
+      let(:subject) { described_class.current }
       before do
         partner_set_env('milsch')
       end
 
       it 'sets current.id to milsch' do
-        expect(described_class.current.id).to eql('milsch')
+        expect(subject.id).to eql('milsch')
       end
       it 'responds to milsch?' do
-        expect(described_class.current).to be_milsch
+        expect(subject).to be_milsch
+      end
+      it 'returns partner name' do
+        expect(subject.name).to eq("Millennium Scholars Program")
+      end
+      it 'returns partner email' do
+        expect(subject.email_address).to eq("millennium@psu.edu")
+      end
+      it 'returns partner email list' do
+        expect(subject.email_list).to eq('ul-etda-milsch-admin@pennstateoffice365.onmicrosoft.com')
+      end
+      it 'returns partner slug' do
+        expect(subject.slug).to eq("MSPT")
+      end
+      it 'returns partner label' do
+        expect(subject.program_label).to eq("Millennium Scholars Program Name")
+      end
+      it 'returns partner committee label' do
+        expect(subject.committee_label).to eq("Thesis Supervisor")
+      end
+      it 'returns partner committee list label' do
+        expect(subject.committee_list_label).to eq("Thesis Supervisor")
       end
     end
 
     context "when ENV['PARTNER'] is sset" do
+      let(:subject) { described_class.current }
       before do
         partner_set_env('sset')
       end
 
       it 'sets current.id to sset' do
-        expect(described_class.current.id).to eql('sset')
+        expect(subject.id).to eql('sset')
       end
       it 'responds to sset?' do
-        expect(described_class.current).to be_sset
+        expect(subject).to be_sset
+      end
+      it 'returns partner name' do
+        expect(subject.name).to eq("School of Science, Engineering, and Technology")
+      end
+      it 'returns partner email' do
+        expect(subject.email_address).to eq("sset@psu.edu")
+      end
+      it 'returns partner email list' do
+        expect(subject.email_list).to eq('ul-etda-sset-admin@pennstateoffice365.onmicrosoft.com')
+      end
+      it 'returns partner slug' do
+        expect(subject.slug).to eq("SSETT")
       end
     end
 

--- a/spec/lib/etda_utilities_partner_spec.rb
+++ b/spec/lib/etda_utilities_partner_spec.rb
@@ -1,156 +1,158 @@
 # frozen_string_literal: true
 
 RSpec.describe EtdaUtilities::Partner, type: :model do
-  describe 'current_partner.id' do
-    context "when ENV['PARTNER'] is graduate" do
-      let(:subject) { described_class.current }
-      before do
-        partner_set_env('graduate')
-      end
+  context "when ENV['PARTNER'] is graduate" do
+    let(:current_partner) { described_class.current }
 
-      it 'sets current.id to graduate' do
-        expect(subject.id).to eql('graduate')
-      end
-      it 'responds to graduate?' do
-        expect(subject).to be_graduate
-      end
-      it 'returns partner name' do
-        expect(subject.name).to eq("Graduate School")
-      end
-      it 'returns partner email' do
-        expect(subject.email_address).to eq("gradthesis@psu.edu")
-      end
-      it 'returns partner email list' do
-        expect(subject.email_list).to eq('ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com')
-      end
-      it 'returns partner slug' do
-        expect(subject.slug).to eq("eTD")
-      end
-      it 'returns partner label' do
-        expect(subject.program_label).to eq("Graduate Program")
-      end
-      it 'returns partner committee label' do
-        expect(subject.committee_label).to eq("Committee Member")
-      end
-      it 'returns partner committee list label' do
-        expect(subject.committee_list_label).to eq("Committee Members")
-      end
+    before do
+      partner_set_env('graduate')
     end
 
-    context "when ENV['PARTNER'] is honors" do
-      let(:subject) { described_class.current }
-      before do
-        partner_set_env('honors')
-      end
+    it 'sets current.id to graduate' do
+      expect(current_partner.id).to eql('graduate')
+    end
+    it 'responds to graduate?' do
+      expect(current_partner).to be_graduate
+    end
+    it 'returns partner name' do
+      expect(current_partner.name).to eq("Graduate School")
+    end
+    it 'returns partner email' do
+      expect(current_partner.email_address).to eq("gradthesis@psu.edu")
+    end
+    it 'returns partner email list' do
+      expect(current_partner.email_list).to eq('ul-etda-graduate-admin@pennstateoffice365.onmicrosoft.com')
+    end
+    it 'returns partner slug' do
+      expect(current_partner.slug).to eq("eTD")
+    end
+    it 'returns partner label' do
+      expect(current_partner.program_label).to eq("Graduate Program")
+    end
+    it 'returns partner committee label' do
+      expect(current_partner.committee_label).to eq("Committee Member")
+    end
+    it 'returns partner committee list label' do
+      expect(current_partner.committee_list_label).to eq("Committee Members")
+    end
+  end
 
-      it 'sets current.id to honors' do
-        expect(subject.id).to eql('honors')
-      end
-      it 'responds to honors?' do
-        expect(subject).to be_honors
-      end
-      it 'returns partner name' do
-        expect(subject.name).to eq("Schreyer Honors College")
-      end
-      it 'returns partner email' do
-        expect(subject.email_address).to eq("SHCAcademics@psu.edu")
-      end
-      it 'returns partner email list' do
-        expect(subject.email_list).to eq('ul-etda-honors-admin@pennstateoffice365.onmicrosoft.com')
-      end
-      it 'returns partner slug' do
-        expect(subject.slug).to eq("eHT")
-      end
-      it 'returns partner label' do
-        expect(subject.program_label).to eq("Area of Honors")
-      end
-      it 'returns partner committee label' do
-        expect(subject.committee_label).to eq("Thesis Supervisor")
-      end
-      it 'returns partner committee list label' do
-        expect(subject.committee_list_label).to eq("Thesis Supervisors")
-      end
+  context "when ENV['PARTNER'] is honors" do
+    let(:current_partner) { described_class.current }
+
+    before do
+      partner_set_env('honors')
     end
 
-    context "when ENV['PARTNER'] is milsch" do
-      let(:subject) { described_class.current }
-      before do
-        partner_set_env('milsch')
-      end
+    it 'sets current.id to honors' do
+      expect(current_partner.id).to eql('honors')
+    end
+    it 'responds to honors?' do
+      expect(current_partner).to be_honors
+    end
+    it 'returns partner name' do
+      expect(current_partner.name).to eq("Schreyer Honors College")
+    end
+    it 'returns partner email' do
+      expect(current_partner.email_address).to eq("SHCAcademics@psu.edu")
+    end
+    it 'returns partner email list' do
+      expect(current_partner.email_list).to eq('ul-etda-honors-admin@pennstateoffice365.onmicrosoft.com')
+    end
+    it 'returns partner slug' do
+      expect(current_partner.slug).to eq("eHT")
+    end
+    it 'returns partner label' do
+      expect(current_partner.program_label).to eq("Area of Honors")
+    end
+    it 'returns partner committee label' do
+      expect(current_partner.committee_label).to eq("Thesis Supervisor")
+    end
+    it 'returns partner committee list label' do
+      expect(current_partner.committee_list_label).to eq("Thesis Supervisors")
+    end
+  end
 
-      it 'sets current.id to milsch' do
-        expect(subject.id).to eql('milsch')
-      end
-      it 'responds to milsch?' do
-        expect(subject).to be_milsch
-      end
-      it 'returns partner name' do
-        expect(subject.name).to eq("Millennium Scholars Program")
-      end
-      it 'returns partner email' do
-        expect(subject.email_address).to eq("millennium@psu.edu")
-      end
-      it 'returns partner email list' do
-        expect(subject.email_list).to eq('ul-etda-milsch-admin@pennstateoffice365.onmicrosoft.com')
-      end
-      it 'returns partner slug' do
-        expect(subject.slug).to eq("MSPT")
-      end
-      it 'returns partner label' do
-        expect(subject.program_label).to eq("Millennium Scholars Program Name")
-      end
-      it 'returns partner committee label' do
-        expect(subject.committee_label).to eq("Thesis Supervisor")
-      end
-      it 'returns partner committee list label' do
-        expect(subject.committee_list_label).to eq("Thesis Supervisor")
-      end
+  context "when ENV['PARTNER'] is milsch" do
+    let(:current_partner) { described_class.current }
+
+    before do
+      partner_set_env('milsch')
     end
 
-    context "when ENV['PARTNER'] is sset" do
-      let(:subject) { described_class.current }
-      before do
-        partner_set_env('sset')
-      end
+    it 'sets current.id to milsch' do
+      expect(current_partner.id).to eql('milsch')
+    end
+    it 'responds to milsch?' do
+      expect(current_partner).to be_milsch
+    end
+    it 'returns partner name' do
+      expect(current_partner.name).to eq("Millennium Scholars Program")
+    end
+    it 'returns partner email' do
+      expect(current_partner.email_address).to eq("millennium@psu.edu")
+    end
+    it 'returns partner email list' do
+      expect(current_partner.email_list).to eq('ul-etda-milsch-admin@pennstateoffice365.onmicrosoft.com')
+    end
+    it 'returns partner slug' do
+      expect(current_partner.slug).to eq("MSPT")
+    end
+    it 'returns partner label' do
+      expect(current_partner.program_label).to eq("Millennium Scholars Program Name")
+    end
+    it 'returns partner committee label' do
+      expect(current_partner.committee_label).to eq("Thesis Supervisor")
+    end
+    it 'returns partner committee list label' do
+      expect(current_partner.committee_list_label).to eq("Thesis Supervisor")
+    end
+  end
 
-      it 'sets current.id to sset' do
-        expect(subject.id).to eql('sset')
-      end
-      it 'responds to sset?' do
-        expect(subject).to be_sset
-      end
-      it 'returns partner name' do
-        expect(subject.name).to eq("School of Science, Engineering, and Technology")
-      end
-      it 'returns partner email' do
-        expect(subject.email_address).to eq("sset@psu.edu")
-      end
-      it 'returns partner email list' do
-        expect(subject.email_list).to eq('ul-etda-sset-admin@pennstateoffice365.onmicrosoft.com')
-      end
-      it 'returns partner slug' do
-        expect(subject.slug).to eq("SSETT")
-      end
+  context "when ENV['PARTNER'] is sset" do
+    let(:current_partner) { described_class.current }
+
+    before do
+      partner_set_env('sset')
     end
 
-    context "when ENV['PARTNER'] is not a valid partner" do
-      before do
-        partner_set_env('boguspartner')
-      end
+    it 'sets current.id to sset' do
+      expect(current_partner.id).to eql('sset')
+    end
+    it 'responds to sset?' do
+      expect(current_partner).to be_sset
+    end
+    it 'returns partner name' do
+      expect(current_partner.name).to eq("School of Science, Engineering, and Technology")
+    end
+    it 'returns partner email' do
+      expect(current_partner.email_address).to eq("sset@psu.edu")
+    end
+    it 'returns partner email list' do
+      expect(current_partner.email_list).to eq('ul-etda-sset-admin@pennstateoffice365.onmicrosoft.com')
+    end
+    it 'returns partner slug' do
+      expect(current_partner.slug).to eq("SSETT")
+    end
+  end
 
-      it 'reports an error' do
-        expect { described_class.current.id }.to raise_error(ArgumentError)
-      end
+  context "when ENV['PARTNER'] is not a valid partner" do
+    before do
+      partner_set_env('boguspartner')
     end
 
-    context "when ENV['PARTNER'] is not set" do
-      before do
-        ENV.delete('PARTNER')
-      end
+    it 'reports an error' do
+      expect { described_class.current.id }.to raise_error(ArgumentError)
+    end
+  end
 
-      it 'reports an error' do
-        expect { described_class.current.id }.to raise_error(KeyError)
-      end
+  context "when ENV['PARTNER'] is not set" do
+    before do
+      ENV.delete('PARTNER')
+    end
+
+    it 'reports an error' do
+      expect { described_class.current.id }.to raise_error(KeyError)
     end
   end
 end


### PR DESCRIPTION
Moves shared partner methods from workflow and explore into EtdaUtilities::Partner class.

Fixes part of https://github.com/psu-libraries/etda_explore/issues/1 .  I want to test installing this on our new Explore to see if it works before merging.